### PR TITLE
Passing the adapter to the dao query operation

### DIFF
--- a/ontimize-jee-server/src/main/java/com/ontimize/jee/server/dao/DefaultOntimizeDaoHelper.java
+++ b/ontimize-jee-server/src/main/java/com/ontimize/jee/server/dao/DefaultOntimizeDaoHelper.java
@@ -190,7 +190,7 @@ public class DefaultOntimizeDaoHelper implements IOntimizeDaoHelper, Application
 	@Override
 	public <T> List<T> query(IOntimizeDaoSupport dao, Map<?, ?> keysValues, List<?> sort, String queryId, Class<T> clazz, ISQLQueryAdapter adapter) {
 		CheckingTools.failIfNull(dao, "Null dao");
-		return dao.query(keysValues, sort, queryId, clazz);
+		return dao.query(keysValues, sort, queryId, clazz, adapter);
 	}
 
 	/*


### PR DESCRIPTION
The adapter parameter is not added to the dao query operation.
This modification should fix it! 