### PR TITLE
Disable Jacoco module, avoid implicit version of httpclient

### DIFF
--- a/ontimize-jee-server-jdbc/src/main/java/com/ontimize/jee/server/dao/jdbc/OntimizeJdbcDaoSupport.java
+++ b/ontimize-jee-server-jdbc/src/main/java/com/ontimize/jee/server/dao/jdbc/OntimizeJdbcDaoSupport.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 import javax.sql.DataSource;
 import javax.xml.bind.JAXB;
 
-import org.apache.poi.ss.formula.functions.T;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <module>ontimize-jee-server-jdbc</module>
         <module>ontimize-jee-server-keycloak</module>
         <module>ontimize-jee-webclient-addons</module>
-        <module>ontimize-jee-jacoco</module>
+<!--        <module>ontimize-jee-jacoco</module>-->
     </modules>
 
     <properties>
@@ -534,6 +534,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
+                <version>${httpclient.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Disable Jacoco module, avoid implicit version of httpclient and remove unused import

### Changes in this PR

...

### Is CHANGELOG.md updated?
- [ ] Yes
- [X] Not applicable  —  I’ve added the `skip-changelog` label
